### PR TITLE
chore: prevent bundling of native SQL adapters

### DIFF
--- a/src/db/adapter.js
+++ b/src/db/adapter.js
@@ -36,7 +36,8 @@ export async function createDB() {
     // Desktop: Tauri SQLite (only import when actually running in Tauri)
     dbPromise = (async () => {
       try {
-        const { Database } = await import('tauri-plugin-sql-api');
+        // Use a vite-ignore comment so the module isn't bundled during web builds
+        const { Database } = await import(/* @vite-ignore */ 'tauri-plugin-sql-api');
         const db = await Database.load('sqlite:bible.sqlite');
         
         return {
@@ -55,7 +56,8 @@ export async function createDB() {
     // Mobile: Capacitor SQLite
     dbPromise = (async () => {
       try {
-        const { CapacitorSQLite } = await import('@capacitor-community/sqlite');
+        // Same treatment for Capacitor plugin which isn't present in web builds
+        const { CapacitorSQLite } = await import(/* @vite-ignore */ '@capacitor-community/sqlite');
         const sqlite = CapacitorSQLite;
         
         const ret = await sqlite.createConnection('bible', false, 'no-encryption', 1, false);


### PR DESCRIPTION
## Summary
- skip bundling of Tauri and Capacitor SQL plugins with vite-ignore

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b33942d48c8331bb51ef9e65524d21