### PR TITLE
Fix Cloudflare Pages config and remove eval-based imports

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-# Handle React Router client-side routing
-/*    /index.html   200
+/assets/*     /assets/:splat  200
+/*            /index.html     200

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,19 +1,3 @@
-name = "bible-sync-worker"
-main = "workers/sync-worker.js"
-compatibility_date = "2024-07-01"
-
-# Hyperdrive binding for PostgreSQL connection
-[[hyperdrive]]
-binding = "HYPERDRIVE"
-id = "YOUR_HYPERDRIVE_ID"  # You'll need to create this
-database_id = "YOUR_DATABASE_ID"
-
-# D1 binding for edge cache
-[[d1_databases]]
-binding = "D1_DATABASE"
-database_name = "bible-cache"
-database_id = "YOUR_D1_ID"  # You'll need to create this
-
-# Scheduled trigger - runs every Sunday at 2 AM UTC
-[triggers]
-crons = ["0 2 * * 0"]
+name = "bible-app"
+pages_build_output_dir = "dist"
+compatibility_date = "2024-11-21"


### PR DESCRIPTION
## Summary
- provide minimal wrangler configuration for Pages
- add explicit SPA redirects for assets and index
- remove eval() from db adapter and use runtime environment detection

## Testing
- `npm run lint` (fails: unused variable errors in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b396074860833199b650bcd2ea6d2c